### PR TITLE
Allow azure_providers to be disabled

### DIFF
--- a/.azuredevops/README.md
+++ b/.azuredevops/README.md
@@ -110,6 +110,8 @@ If the environment is configured with **Approvers**, the job will require manual
 
   The pipeline create job will try to register the specified providers in addition to the providers that is detected in code by deployment validate.
 
+  Use the value **"disable"** to prevent the pipeline from trying to register Azure resource providers.
+
 - **AZURE_PROVIDER_WAIT_SECONDS**: Seconds to wait between each provider status check.
 
 - **AZURE_PROVIDER_WAIT_COUNT**: Times to check provider status before giving up.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,6 +22,21 @@ body:
       description: What happened?
     validations:
       required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of bicep-action are you running?
+      multiple: false
+      options:
+        - v1.0.4
+        - v1.0.3
+        - v1.0.2
+        - v1.0.1
+        - v1.0.0
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: steps
     attributes:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ with:
 
   The workflow will try to register the specified providers in addition to the providers that is detected in code by deployment validate.
 
+  Use the value **"disable"** to prevent the workflow from trying to register Azure resource providers.
+
   Default: **""**
 
 - **azure_provider_wait_count**: Times to check provider status before giving up.

--- a/scripts/az-bicep.sh
+++ b/scripts/az-bicep.sh
@@ -91,7 +91,7 @@ if [[ "${IN_TEMPLATE}" == 'http'* ]]; then
 fi
 if [[ "${IN_TEMPLATE}" == *".${src_file_extension}" ]]; then
   out_file=$(readlink -f "${IN_TEMPLATE/.${src_file_extension}/.${out_file_extension}}")
-  echo "Set output: file='${out_file}'"
+  echo "Set output file='${out_file}'"
   if test -n "${TF_BUILD-}"; then
     echo "##vso[task.setvariable variable=file;isoutput=true]${out_file}"
   else
@@ -111,7 +111,7 @@ if [[ "${IN_TEMPLATE}" == *".${src_file_extension}" ]]; then
 else
   if [[ "${IN_TEMPLATE}" == *".${out_file_extension}" ]]; then
     out_file=$(readlink -f "${IN_TEMPLATE}")
-    echo "Set output: file='${out_file}'"
+    echo "Set output file='${out_file}'"
     if test -n "${TF_BUILD-}"; then
       echo "##vso[task.setvariable variable=file;isoutput=true]${out_file}"
     else

--- a/scripts/az-deploy.sh
+++ b/scripts/az-deploy.sh
@@ -116,9 +116,17 @@ log_output() {
       echo "Resource providers discovered by ${LOG_NAME}:"
       echo "${from_code}"
     fi
-    local list
-    list=$(echo "${IN_PROVIDERS},${from_code}" | xargs)
-    echo "Set output: providers='${list}'"
+    local list=''
+    if [ "$(echo "${IN_PROVIDERS}" | tr '[:upper:]' '[:lower:]')" = 'disable' ]; then
+      list=''
+    elif test -n "${IN_PROVIDERS}" && test -n "${from_code}"; then
+      list="${IN_PROVIDERS},${from_code}"
+    elif test -n "${IN_PROVIDERS}"; then
+      list=$IN_PROVIDERS
+    elif test -n "${from_code}"; then
+      list=$from_code
+    fi
+    echo "Set output providers='${list}'"
     if test -n "${TF_BUILD-}"; then
       echo "##vso[task.setvariable variable=providers;isOutput=true]${list}"
     else

--- a/scripts/azure-providers.sh
+++ b/scripts/azure-providers.sh
@@ -84,7 +84,7 @@ else
 fi
 for provider in "${providers[@]}"; do
   value=$(echo " ${provider} " | tr '[:upper:]' '[:lower:]')
-  if [[ ! " ${registered} " =~ ${value} ]]; then
+  if [[ ! " ${registered} " =~ ${value} ]] && test -n "${provider}"; then
     echo "Register ${provider}..." | tee -a "${log}"
     cmd='az provider register --namespace'
     cmd+=" ${provider}"

--- a/scripts/psrule-config.sh
+++ b/scripts/psrule-config.sh
@@ -28,7 +28,7 @@ else
     fi
   fi
 fi
-echo "Set output: error='${missing}'"
+echo "Set output error='${missing}'"
 if test -n "${TF_BUILD-}"; then
   echo "##vso[task.setvariable variable=error;isoutput=true]${missing}"
 else


### PR DESCRIPTION
- Resolves #7.
- When input **"azure_providers"** is set to **"disable"**, the deploy job will not **"register providers"**. 
- Add version field to bug issue template.
